### PR TITLE
fix: don't check VERSION file for changes between SDK versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Commit & Push SDK and Version Changes
         id: commit_changes
         run: |
-          git add pkg/client pkg/models pkg/transport tests VERSION LICENSE README.md go.mod go.sum
+          git add pkg/client pkg/models pkg/transport tests LICENSE README.md go.mod go.sum
           
           if git diff --staged --quiet; then
             echo "No changes to SDK files or VERSION file. Skipping commit, tag, and release."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release workflow to no longer stage the version file during the commit and push process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->