### PR TITLE
fix: add examples to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Commit & Push SDK and Version Changes
         id: commit_changes
         run: |
-          git add pkg/client pkg/models pkg/transport pkg/utils pkg/types tests LICENSE README.md go.mod go.sum
+          git add pkg/client pkg/models pkg/transport pkg/utils pkg/types tests LICENSE README.md go.mod go.sum examples
           
           if git diff --staged --quiet; then
             echo "No changes to SDK files. Skipping commit, tag, and release."


### PR DESCRIPTION
include the `examples` folder in the changes that get committed to the repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to include changes from the examples directory in release commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->