### PR TITLE
Fix policies e2e sdk tests

### DIFF
--- a/tests/e2e/policies_test.go
+++ b/tests/e2e/policies_test.go
@@ -25,7 +25,7 @@ func TestPoliciesEndpoints(t *testing.T) {
 			Name:        &policyName,
 			Description: policyDesc,
 			Role: models.RoleMap{
-				"default": "viewer",
+				"write": "",
 			},
 			DataScope: &models.DataScope{},
 		}
@@ -111,7 +111,7 @@ func TestPoliciesEndpoints(t *testing.T) {
 
 		// 1. Define updates
 		updatedDesc := "Policy updated during E2E testing"
-		updatedRoleMap := models.RoleMap{"default": "admin"} // Change role to admin
+		updatedRoleMap := models.RoleMap{"admin": ""} // Change role to admin
 		// Hardcode initial revision - adjust if API requires different initial value
 		// Alternatively, if createResp *did* return revision, use that.
 		var assumedCurrentRevision int32 = 1 // Adjust this if needed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end policy tests to reflect current role mappings: Create Policy now uses a write role instead of a default viewer, and Update Policy uses an admin role instead of a default admin.
  * Improves test accuracy and alignment with current behavior; no changes to user-facing functionality or policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->